### PR TITLE
/me Endpoint in authcontroller to return email + test

### DIFF
--- a/src/main/java/com/group7/krisefikser/controller/AuthController.java
+++ b/src/main/java/com/group7/krisefikser/controller/AuthController.java
@@ -17,6 +17,9 @@ import java.util.logging.Logger;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -166,5 +169,30 @@ public class AuthController {
           new AuthResponse(AuthResponseMessage.EMAIL_VERIFICATION_ERROR.getMessage()
                   + e.getMessage(), null, null));
     }
+  }
+
+  /**
+   * Endpoint for getting the current user's email.
+   * This method retrieves the email of the currently authenticated user.
+   *
+   * @return a ResponseEntity containing the user's email or no content if not authenticated
+   */
+  @Operation(
+      summary = "Get current user email",
+      description = "Returns the email of the currently authenticated user,"
+       + "or no content if not authenticated."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "Authenticated – returns email"),
+      @ApiResponse(responseCode = "204", description = "Not authenticated – no content")
+  })
+  @GetMapping("/me")
+  public ResponseEntity<String> getCurrentUserEmail() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    if (auth != null && auth.isAuthenticated()
+         && !(auth instanceof AnonymousAuthenticationToken)) {
+      return ResponseEntity.ok(auth.getName());
+    }
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/test/java/com/group7/krisefikser/controller/AuthControllerTest.java
+++ b/src/test/java/com/group7/krisefikser/controller/AuthControllerTest.java
@@ -152,4 +152,18 @@ class AuthControllerTest {
         .andExpect(jsonPath("$.expiryDate").doesNotExist())
         .andExpect(jsonPath("$.role").doesNotExist());
   }
+
+  @WithMockUser(username = "johndoe@test.com")
+  @Test
+  void getCurrentUserEmail_authenticated_returnsEmail() throws Exception {
+    mockMvc.perform(get("/api/auth/me"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("johndoe@test.com"));
+  }
+
+  @Test
+  void getCurrentUserEmail_unauthenticated_returnsNoContent() throws Exception {
+    mockMvc.perform(get("/api/auth/me"))
+        .andExpect(status().isNoContent());
+  }
 }


### PR DESCRIPTION

<!--
  Thanks for contributing 🙌
  Please fill out as much of this template as makes sense for your change.
-->

## 📋 Description

<!-- A concise explanation of **what** this PR does and **why**.
     If this addresses an open issue, link it with “Fixes #123”. -->

added a /me endpoint to authcontroller that basically just returns an email if there is a user logged in, and returns nothing if there isnt a user. using this for reactive navbar and other stuff in the frontend.. also wrote a test for this.. fixed checkstyle aswell

## 🔗 Related issue(s) / PR(s)

<!-- e.g. Closes #123, Depends on #456, etc. -->

## 🧰 Type of change

- [ ] 🐞 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor / tech debt
- [ ] 📝 Documentation only
- [ ] ⚠️ Breaking change
- [ ] 🔒 Security fix
- [ ] 🚦 CI / tooling

## ✅ Acceptance criteria

- [ ] Code compiles & passes existing tests
- [ ] New / updated tests added
- [ ] Documentation updated (README, comments, wiki)
- [ ] Follows project coding style / guidelines
- [ ] No new ESLint/TSLint/SwiftLint/etc. warnings
- [ ] Tested on all supported browsers / OSs / platforms

## 📝 Implementation notes

<!-- Anything reviewers should know about peculiar decisions, trade-offs, etc. -->

## 📸 Screenshots / GIFs (if UI change)

<!-- Drag in images or paste links -->

## 📚 Further context

<!-- Links to architecture docs, RFCs, upstream discussion, performance data, etc. -->

## 👥 Reviewer checklist (maintainer use)

- [ ] PR title & description are clear
- [ ] Commit history is tidy (squashed / labelled appropriately)
- [ ] All CI checks pass
- [ ] Labels & milestone applied
- [ ] Ready to merge 🚀
