### PR TITLE
Restict forgot password to normal users

### DIFF
--- a/src/main/java/com/group7/krisefikser/config/SecurityConfig.java
+++ b/src/main/java/com/group7/krisefikser/config/SecurityConfig.java
@@ -59,10 +59,7 @@ public class SecurityConfig {
     http.cors(cors -> cors.configurationSource(source))
         .csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(authorize -> authorize
-            .requestMatchers(HttpMethod.POST, "/api/auth/new-password-link")
-                .hasAnyRole("NORMAL")
-
-            .requestMatchers(HttpMethod.GET,
+             .requestMatchers(HttpMethod.GET,
                 "/api/affected-area",
                 "/api/point-of-interest",
                 "/h2-console/**",

--- a/src/main/java/com/group7/krisefikser/controller/AuthController.java
+++ b/src/main/java/com/group7/krisefikser/controller/AuthController.java
@@ -347,7 +347,7 @@ public class AuthController {
       return ResponseEntity.ok("New password link sent to: " + email);
     } catch (IllegalArgumentException e) {
       logger.warning(e.getMessage());
-      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Could not sent new "
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Could not send new "
               + "password link to: " + email);
     } catch (Exception e) {
       logger.severe("Error sending new password link to " + email + ": " + e.getMessage());

--- a/src/main/java/com/group7/krisefikser/controller/AuthController.java
+++ b/src/main/java/com/group7/krisefikser/controller/AuthController.java
@@ -339,13 +339,16 @@ public class AuthController {
   @PostMapping("/new-password-link")
   public ResponseEntity<Object> sendNewPasswordLink(
       @Valid @RequestBody ResetPasswordLinkRequest request) {
-    
     String email = request.getEmail();
     logger.info("Trying to send new password link to: " + email);
     try {
       userService.sendResetPasswordLink(email);
       logger.info("New password link sent to: " + email);
       return ResponseEntity.ok("New password link sent to: " + email);
+    } catch (IllegalArgumentException e) {
+      logger.warning(e.getMessage());
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Could not sent new "
+              + "password link to: " + email);
     } catch (Exception e) {
       logger.severe("Error sending new password link to " + email + ": " + e.getMessage());
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();

--- a/src/main/java/com/group7/krisefikser/service/UserService.java
+++ b/src/main/java/com/group7/krisefikser/service/UserService.java
@@ -245,6 +245,10 @@ public class UserService implements UserDetailsService {
     Optional<User> userOpt = userRepo.findByEmail(email);
     if (userOpt.isPresent()) {
       User user = userOpt.get();
+      if (user.getRole() == Role.ROLE_ADMIN) {
+        throw new IllegalArgumentException("Admin users cannot reset their password");
+      }
+
       String resetToken = jwtUtils.generateResetPasswordToken(user.getEmail());
       String resetLink = frontendUrl + "/reset-password?token=" + resetToken;
       Map<String, String> params = Map.of("resetLink", resetLink);

--- a/src/main/java/com/group7/krisefikser/utils/JwtUtils.java
+++ b/src/main/java/com/group7/krisefikser/utils/JwtUtils.java
@@ -35,7 +35,6 @@ public class JwtUtils {
 
   private static final Duration JWT_VALIDITY = Duration.ofMinutes(120);
   private static final Duration JWT_INVITE_VALIDITY = Duration.ofMinutes(60);
-  private static final Duration JWT_VERIFICATION_VALIDITY = Duration.ofMinutes(10);
   private final Logger logger = LoggerFactory.getLogger(JwtUtils.class);
 
   /**
@@ -155,7 +154,7 @@ public class JwtUtils {
       .withSubject(email)
       .withIssuer("krisefikser")
       .withIssuedAt(now)
-      .withExpiresAt(now.plusMillis(JWT_VERIFICATION_VALIDITY.toMillis()))
+      .withExpiresAt(now.plusMillis(JWT_INVITE_VALIDITY.toMillis()))
       .sign(getKey(verificationSecretKey));
   }
 
@@ -172,7 +171,7 @@ public class JwtUtils {
       .withSubject(email)
       .withIssuer("krisefikser")
       .withIssuedAt(now)
-      .withExpiresAt(now.plusMillis(JWT_VERIFICATION_VALIDITY.toMillis()))
+      .withExpiresAt(now.plusMillis(JWT_INVITE_VALIDITY.toMillis()))
       .sign(getKey(invitationSecretKey));
   }
 
@@ -208,7 +207,7 @@ public class JwtUtils {
         .withSubject(email)
         .withIssuer("krisefikser")
         .withIssuedAt(now)
-        .withExpiresAt(now.plusMillis(JWT_VERIFICATION_VALIDITY.toMillis()))
+        .withExpiresAt(now.plusMillis(JWT_INVITE_VALIDITY.toMillis()))
         .sign(getKey(resetPasswordSecretKey));
   }
 


### PR DESCRIPTION
## 📋 Description

Only normal users should be able to use the forgot password link, admins should get link from a super admin

## 🧰 Type of change

- [ ] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor / tech debt
- [ ] 📝 Documentation only
- [ ] ⚠️ Breaking change
- [ ] 🔒 Security fix
- [ ] 🚦 CI / tooling

## ✅ Acceptance criteria

- [ ] Admins cant use reset password, while users can
- [ ] 

## 📝 Implementation notes

<!-- Anything reviewers should know about peculiar decisions, trade-offs, etc. -->

## 📸 Screenshots / GIFs (if UI change)

<!-- Drag in images or paste links -->

## 📚 Further context

<!-- Links to architecture docs, RFCs, upstream discussion, performance data, etc. -->

## 👥 Reviewer checklist (maintainer use)

- [ ] PR title & description are clear
- [ ] Commit history is tidy (squashed / labelled appropriately)
- [ ] All CI checks pass
- [ ] Labels & milestone applied
- [ ] Ready to merge 🚀
